### PR TITLE
Use bazel-like space separated target specification

### DIFF
--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -63,7 +63,7 @@ pub fn get_crate_specs(
     bazel: &Path,
     workspace: &Path,
     execution_root: &Path,
-    targets: &[&str],
+    targets: &[String],
     rules_rust_name: &str,
 ) -> anyhow::Result<Vec<CrateSpec>> {
     log::debug!("Get crate specs with targets: {:?}", targets);

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -11,7 +11,7 @@ pub fn generate_crate_info(
     bazel: impl AsRef<Path>,
     workspace: impl AsRef<Path>,
     rules_rust: impl AsRef<str>,
-    targets: &[&str],
+    targets: &[String],
 ) -> anyhow::Result<()> {
     log::debug!("Building rust_analyzer_crate_spec files for {:?}", targets);
 
@@ -41,7 +41,7 @@ pub fn write_rust_project(
     bazel: impl AsRef<Path>,
     workspace: impl AsRef<Path>,
     rules_rust_name: &impl AsRef<str>,
-    targets: &[&str],
+    targets: &[String],
     execution_root: impl AsRef<Path>,
     rust_project_path: impl AsRef<Path>,
 ) -> anyhow::Result<()> {
@@ -53,7 +53,7 @@ pub fn write_rust_project(
         rules_rust_name.as_ref(),
     )?;
 
-    let workspace_name = match rules_rust_name.as_ref().trim_start_matches("@") {
+    let workspace_name = match rules_rust_name.as_ref().trim_start_matches('@') {
         "" => "rules_rust",
         s => s,
     };

--- a/tools/rust_analyzer/main.rs
+++ b/tools/rust_analyzer/main.rs
@@ -114,7 +114,7 @@ struct Config {
     #[structopt(long, default_value = "bazel")]
     bazel: PathBuf,
 
-    /// Comma-separated list of target patterns
+    // Space separated list of target patterns that comes after all other args.
     #[structopt(default_value = "@//...")]
     targets: Vec<String>,
 }

--- a/tools/rust_analyzer/main.rs
+++ b/tools/rust_analyzer/main.rs
@@ -26,19 +26,22 @@ fn main() -> anyhow::Result<()> {
         .as_ref()
         .expect("failed to find execution root, is --execution-root set correctly?");
 
-    let targets: Vec<&str> = config.targets.split(',').collect();
-
     let rules_rust_name = env!("ASPECT_REPOSITORY");
 
     // Generate the crate specs.
-    generate_crate_info(&config.bazel, &workspace_root, &rules_rust_name, &targets)?;
+    generate_crate_info(
+        &config.bazel,
+        &workspace_root,
+        &rules_rust_name,
+        &config.targets,
+    )?;
 
     // Use the generated files to write rust-project.json.
     write_rust_project(
         &config.bazel,
         &workspace_root,
         &rules_rust_name,
-        &targets,
+        &config.targets,
         &execution_root,
         &workspace_root.join("rust-project.json"),
     )?;
@@ -112,6 +115,6 @@ struct Config {
     bazel: PathBuf,
 
     /// Comma-separated list of target patterns
-    #[structopt(long, default_value = "@//...")]
-    targets: String,
+    #[structopt(default_value = "@//...")]
+    targets: Vec<String>,
 }


### PR DESCRIPTION
I gave up on the ideal of &str because I was wrestling the type system getting increasingly absurd and it just didn't seem worth it for this.